### PR TITLE
prevent possibility of stack overflow

### DIFF
--- a/circles.lua
+++ b/circles.lua
@@ -177,12 +177,12 @@ function CIRCLE:Calculate()
 		local inner = self.m_ChildCircle or self:Copy()
 		local inner_r = radius - self.m_OutlineWidth
 
+		inner:SetType(CIRCLE_FILLED)
+
 		if inner_r >= radius then
 			self:SetShouldRender(false)
 		else
 			if inner_r >= 1 then
-				inner:SetType(CIRCLE_FILLED)
-
 				inner:SetRadius(inner_r)
 				inner:SetAngles(start_angle, end_angle)
 


### PR DESCRIPTION
Hello, a player has catched a really weird error related to **stack overflow**, I couldn't personally replicate this issue, but my guess this **PR** should fix any **possible** similar case.

Adding a link to an edited library file posted on **pastebin**, so it will better match with lines in error message. I made there some minor changes related to accessing the library, but they are unrelated to the error.
[Library file (without fix)](https://pastebin.com/KE3VjaCE)

**Error message:**
```
[ERROR] stack overflow
   1. istable - [C]:-1
   2. Copy - lua/includes/extensions/table.lua:30
      3. Copy - lua/includes/extensions/table.lua:38
      4. Copy - lua/includes/extensions/table.lua:38
      5. Calculate - gamemodes/axe/gamemode/core/libraries/thirdparty/cl_circle.lua:172
         6. m_ChildCircle - gamemodes/axe/gamemode/core/libraries/thirdparty/cl_circle.lua:208
         7. m_ChildCircle - gamemodes/axe/gamemode/core/libraries/thirdparty/cl_circle.lua:242
         8. m_ChildCircle - gamemodes/axe/gamemode/core/libraries/thirdparty/cl_circle.lua:242
            9. m_ChildCircle - gamemodes/axe/gamemode/core/libraries/thirdparty/cl_circle.lua:242
            10. m_ChildCircle - gamemodes/axe/gamemode/core/libraries/thirdparty/cl_circle.lua:242
            11. m_ChildCircle - gamemodes/axe/gamemode/core/libraries/thirdparty/cl_circle.lua:242
               12. m_ChildCircle - gamemodes/axe/gamemode/core/libraries/thirdparty/cl_circle.lua:242
   ```