### PR TITLE
Use _G Instead of _R

### DIFF
--- a/circles.lua
+++ b/circles.lua
@@ -1,7 +1,5 @@
 if SERVER then return false end
-
-local _R = debug.getregistry()
-if _R.Circles then return _R.Circles end
+if Circles then return Circles end
 
 local CIRCLE = {}
 CIRCLE.__index = CIRCLE
@@ -474,12 +472,11 @@ do
 	end
 end
 
-_R.Circles = {
+Circles = {
 	_MT = CIRCLE,
-
 	New = New,
 	RotateVertices = RotateVertices,
 	CalculateVertices = CalculateVertices,
 }
 
-return _R.Circles
+return Circles


### PR DESCRIPTION
It seems Rubat broke debug.getregistry, and I cannot find any information on why or if it will ever be fixed. Since this library uses the registry, it seems as though it's completely broken currently. Storing the table in _G should fix this with the same functionality.